### PR TITLE
send/sync fix to prevent misuse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,8 @@ impl<T: Sized> Drop for AtomicBox<T> {
     }
 }
 
-unsafe impl<T: Sized> Sync for AtomicBox<T> {}
-unsafe impl<T: Sized> Send for AtomicBox<T> {}
+unsafe impl<T: Sized + Sync> Sync for AtomicBox<T> {}
+unsafe impl<T: Sized + Send> Send for AtomicBox<T> {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Fixes #1

Added correct trait bounds to `Send`/`Sync` impls
in order to prevent misuse and maintain thread safety at compile time.

Thank you for reviewing this PR :+1: 